### PR TITLE
Do not include version in artifact name

### DIFF
--- a/.github/workflows/create-artifact.yml
+++ b/.github/workflows/create-artifact.yml
@@ -16,15 +16,15 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
     - run: npm install
     - run: make archive
-    - run: cp XSignature.zip Paw-TicketEvolutionXSignature-${{ env.GITHUB_REF }}.zip
+    - run: cp XSignature.zip Paw-TicketEvolutionXSignature.zip
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ env.GITHUB_REF }}
-        release_name: ${{ env.GITHUB_REF }}
+        tag_name: ${{ github.ref }}
+        release_name: ${{ github.ref }}
         draft: false
         prerelease: false
     - name: Upload Release Asset
@@ -34,6 +34,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./Paw-TicketEvolutionXSignature-${{ env.GITHUB_REF }}.zip
-        asset_name: Paw-TicketEvolutionXSignature-${{ env.GITHUB_REF }}.zip
+        asset_path: ./Paw-TicketEvolutionXSignature.zip
+        asset_name: Paw-TicketEvolutionXSignature.zip
         asset_content_type: application/zip


### PR DESCRIPTION
The `create-release` action strips out the `refs/tags/` from the
beginning of `github.ref` and does not provide the tag name as an
output (yet see https://github.com/actions/create-release/pull/10).